### PR TITLE
Better sql for tvl query to allow for old contracts

### DIFF
--- a/src/models/tvl.model.ts
+++ b/src/models/tvl.model.ts
@@ -51,10 +51,15 @@ export const getAllTvlData = async (): Promise<Tvl[]> => {
    */
   const data = await repository
     .createQueryBuilder()
-    .select('DISTINCT ON ("contract", "asset") *')
-    .orderBy('contract')
-    .addOrderBy('asset')
-    .addOrderBy('date', 'DESC')
+    .select('*')
+    .where((qb) => {
+      const subQuery = qb
+        .subQuery()
+        .select('MAX(date)')
+        .from(Tvl, 'tvl')
+        .getQuery()
+      return 'date IN ' + subQuery
+    })
     .getRawMany()
   return data
 }


### PR DESCRIPTION
## Description

This PR changes the sql query that retrieves current platform TVL.

The previous query returns the most recent row for any contract/asset pair.

However, if a contract is deprecated (eg an old amm contract), this would return the most recent row for that contract, when really it should return no rows for that contract.

This is an issue now because I want to upload the data from the legacy backend TVL table into here.

The new query returns only rows where date = max(date), so only rows from the most recent loop of the TVL cron job.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [ ] the pull request targets the *default* branch of the repository (`development`)
- [ ] the code follows the established code style of the repository
  - `npm run lint` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [ ] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #[issue number], fixes #[issue number]
